### PR TITLE
Replacing the use of xpath for link interaction

### DIFF
--- a/page_objects/account_edit_page.robot
+++ b/page_objects/account_edit_page.robot
@@ -3,7 +3,7 @@ Resource    ../global_keywords/global_keywords.robot
 
 
 *** Variables ***
-${ACCOUNT_NAME_INPUT}       id=nome
+${ACCOUNT_NAME_INPUT}            id=nome
 ${ACCOUNT_SAVE_EDIT_BUTTON}      xpath=//button[@class='btn btn-primary']     
 
 

--- a/page_objects/menu_page.robot
+++ b/page_objects/menu_page.robot
@@ -3,9 +3,9 @@ Library    SeleniumLibrary
 
 
 *** Variables ***
-${ACCOUNT_MENU}            xpath=//a[contains(.,'Contas')]
-${OPTION_ADD_ACCOUNT}      xpath=//a[contains(.,'Adicionar')]
-${OPTION_ACCOUNT_LIST}     xpath=//a[contains(.,'Listar')]
+${ACCOUNT_MENU}            link=Contas
+${OPTION_ADD_ACCOUNT}      link=Adicionar
+${OPTION_ACCOUNT_LIST}     link=Listar
 
 
 *** Keywords ***


### PR DESCRIPTION
Previously we used XPATH for link interaction. This improvement replaces XPATH with LINK TEXT.